### PR TITLE
Feat: Implement Inline Confirmation for History Deletion

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 import { getDurationMs, calculateStatus, calculateScheduledTimes, getOccurrences, adjustDateForVacation } from './task-logic.js';
-import { taskTemplate, categoryManagerTemplate, taskViewTemplate, notificationManagerTemplate, taskStatsTemplate, actionAreaTemplate, commonButtonsTemplate, statusManagerTemplate, categoryFilterTemplate, iconPickerTemplate, editProgressTemplate, editCategoryTemplate, editStatusNameTemplate, restoreDefaultsConfirmationTemplate, taskGroupHeaderTemplate, bulkEditFormTemplate, dataMigrationModalTemplate, sensitivityControlsTemplate, historyDeleteConfirmationTemplate, taskViewDeleteConfirmationTemplate, vacationManagerTemplate } from './templates.js';
+import { taskTemplate, categoryManagerTemplate, taskViewTemplate, notificationManagerTemplate, taskStatsTemplate, actionAreaTemplate, commonButtonsTemplate, statusManagerTemplate, categoryFilterTemplate, iconPickerTemplate, editProgressTemplate, editCategoryTemplate, editStatusNameTemplate, restoreDefaultsConfirmationTemplate, taskGroupHeaderTemplate, bulkEditFormTemplate, dataMigrationModalTemplate, sensitivityControlsTemplate, historyDeleteConfirmationTemplate, taskViewDeleteConfirmationTemplate, vacationManagerTemplate, taskViewHistoryDeleteConfirmationTemplate } from './templates.js';
 import { Calendar } from 'https://esm.sh/@fullcalendar/core@6.1.19';
 import dayGridPlugin from 'https://esm.sh/@fullcalendar/daygrid@6.1.19';
 import timeGridPlugin from 'https://esm.sh/@fullcalendar/timegrid@6.1.19';
@@ -1550,14 +1550,25 @@ function openTaskView(eventId, isHistorical, occurrenceDate) {
                 if (calendar) calendar.refetchEvents();
                 deactivateModal(taskViewModal);
                 break;
-            case 'deleteSingleHistoryRecord':
-                // New action for deleting only the historical record
-                if (confirm('Are you sure you want to delete this single history record? This cannot be undone.')) {
-                    appState.historicalTasks = appState.historicalTasks.filter(h => 'hist_' + h.originalTaskId + '_' + h.completionDate !== historyEventId);
-                    saveData();
-                    if (calendar) calendar.refetchEvents();
-                    deactivateModal(taskViewModal);
+            case 'triggerDeleteHistoryRecordFromView':
+                if (confirmationDiv && actionsDiv) {
+                    actionsDiv.classList.add('hidden');
+                    confirmationDiv.innerHTML = taskViewHistoryDeleteConfirmationTemplate(historyEventId, taskId);
+                    taskViewContent.classList.add('task-confirming-delete');
                 }
+                break;
+            case 'cancelDeleteHistoryRecordFromView':
+                 if (confirmationDiv && actionsDiv) {
+                    confirmationDiv.innerHTML = '';
+                    actionsDiv.classList.remove('hidden');
+                    taskViewContent.classList.remove('task-confirming-delete');
+                }
+                break;
+            case 'confirmDeleteHistoryRecordFromView':
+                appState.historicalTasks = appState.historicalTasks.filter(h => 'hist_' + h.originalTaskId + '_' + h.completionDate !== historyEventId);
+                saveData();
+                if (calendar) calendar.refetchEvents();
+                deactivateModal(taskViewModal);
                 break;
         }
     });

--- a/js/templates.js
+++ b/js/templates.js
@@ -234,7 +234,7 @@ function taskViewTemplate(task, { categories, appSettings, isHistorical }) {
 
     // Determine which actions to show
     const actionsHtml = isHistorical ? `
-        <button data-action="deleteSingleHistoryRecord" data-history-event-id="${task.id}" data-task-id="${task.originalTaskId}" class="themed-button-clear">Delete This Record</button>
+        <button data-action="triggerDeleteHistoryRecordFromView" data-history-event-id="${task.id}" data-task-id="${task.originalTaskId}" class="themed-button-clear">Delete This Record</button>
         <button data-action="viewTaskStats" data-task-id="${task.originalTaskId}" class="themed-button-clear">View Parent Task Stats</button>
     ` : `
         <button data-action="triggerDeleteFromView" data-task-id="${task.id}" class="themed-button-clear">Delete Task</button>
@@ -274,7 +274,8 @@ export {
     actionAreaTemplate, commonButtonsTemplate, statusManagerTemplate, categoryFilterTemplate, iconPickerTemplate,
     editProgressTemplate, editCategoryTemplate, editStatusNameTemplate, restoreDefaultsConfirmationTemplate,
     taskGroupHeaderTemplate, bulkEditFormTemplate, dataMigrationModalTemplate, sensitivityControlsTemplate,
-    historyDeleteConfirmationTemplate, taskViewDeleteConfirmationTemplate, vacationManagerTemplate
+    historyDeleteConfirmationTemplate, taskViewDeleteConfirmationTemplate, vacationManagerTemplate,
+    taskViewHistoryDeleteConfirmationTemplate
 };
 
 function vacationManagerTemplate(vacations, categories) {
@@ -333,6 +334,18 @@ function taskViewDeleteConfirmationTemplate(taskId) {
             <div class="flex justify-center space-x-4 mt-3">
                 <button data-action="confirmDeleteFromView" data-task-id="${taskId}" class="themed-button-clear text-red-700 font-bold">Yes, Delete</button>
                 <button data-action="cancelDeleteFromView" data-task-id="${taskId}" class="themed-button-clear">No, Cancel</button>
+            </div>
+        </div>
+    `;
+}
+
+function taskViewHistoryDeleteConfirmationTemplate(historyEventId, originalTaskId) {
+    return `
+        <div class="p-3 rounded-lg border-2 border-dashed border-yellow-500 bg-yellow-50">
+            <p class="text-center text-yellow-800 font-semibold">Delete this specific history record?</p>
+            <div class="flex justify-center space-x-4 mt-3">
+                <button data-action="confirmDeleteHistoryRecordFromView" data-history-event-id="${historyEventId}" data-task-id="${originalTaskId}" class="themed-button-clear text-red-700 font-bold">Yes, Delete Record</button>
+                <button data-action="cancelDeleteHistoryRecordFromView" class="themed-button-clear">No, Cancel</button>
             </div>
         </div>
     `;

--- a/jules-scratch/verification/verify_inline_history_delete.py
+++ b/jules-scratch/verification/verify_inline_history_delete.py
@@ -1,0 +1,78 @@
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run_verification(page: Page):
+    """
+    This function contains the actual test logic. It has been updated to
+    more robustly wait for the task view modal before checking its content.
+    """
+    page.goto("http://localhost:8000")
+    task_name = "History Deletion Test Task"
+
+    try:
+        # 1. Create a new repeating task to generate history
+        page.get_by_role("button", name="Add New Task").click()
+        page.get_by_label("Task Name").fill(task_name)
+
+        page.locator("#simple-mode-toggle").check()
+        page.locator("#task-repetition").select_option("relative")
+        page.locator("#repetition-amount").fill("1")
+        page.locator("#repetition-unit").select_option("days")
+        page.get_by_role("button", name="Save Task").click()
+
+        # 2. Switch to Task Manager view and complete the task
+        page.get_by_role("button", name="Task Manager").click()
+
+        task_list_item = page.locator(f".task-item:has-text('{task_name}')")
+        expect(task_list_item).to_be_visible(timeout=5000)
+        task_list_item.get_by_role("button", name="Complete").click()
+        page.get_by_role("button", name="Yes").click()
+
+        # 3. Navigate to the calendar and find the historical event
+        page.get_by_role("button", name="Calendar").click()
+
+        historical_event = page.locator(f".fc-event:has-text('{task_name}')").first
+        expect(historical_event).to_be_visible(timeout=10000)
+        historical_event.click()
+
+        # 4. Trigger the inline deletion confirmation
+        # First, wait for the modal container itself to be visible.
+        task_view_modal = page.locator("#task-view-modal")
+        expect(task_view_modal).to_be_visible()
+
+        # Now, look for the title within the visible modal.
+        modal_title = task_view_modal.get_by_role("heading", name=task_name)
+        expect(modal_title).to_be_visible()
+
+        page.get_by_role("button", name="Delete This Record").click()
+
+        # 5. Verify the confirmation UI is visible and take screenshot
+        expect(page.get_by_text("Delete this specific history record?")).to_be_visible()
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+        # 6. Confirm the deletion
+        page.get_by_role("button", name="Yes, Delete Record").click()
+
+        # 7. Verify the modal is closed and the event is gone
+        expect(task_view_modal).not_to_be_visible()
+        expect(historical_event).not_to_be_visible()
+
+    finally:
+        # 8. Clean up the active task if it still exists
+        page.get_by_role("button", name="Task Manager").click(force=True)
+
+        task_list_item_cleanup = page.locator(f".task-item:has-text('{task_name}')")
+
+        if task_list_item_cleanup.count() > 0:
+            task_list_item_cleanup.get_by_role("button", name="Delete").click(force=True)
+            task_list_item_cleanup.get_by_role("button", name="Yes").click()
+            expect(task_list_item_cleanup).not_to_be_visible()
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        run_verification(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replaces the browser's `confirm()` dialog when deleting a single historical task record with a modern, inline confirmation UI within the task view modal.

This change follows the existing pattern for deleting active tasks and aligns with the "Standardize Inline Confirmations" guideline in the README.md.

- Adds a new `taskViewHistoryDeleteConfirmationTemplate` for the UI.
- Updates the `taskViewTemplate` to trigger the new confirmation flow.
- Refactors the `openTaskView` event listener in `script.js` to handle the trigger, confirm, and cancel actions for the new inline UI.