### PR TITLE
feat(journal): Add collapsible groups and configurable goal icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ Integrated directly with the task manager, the mission planner provides a high-l
 * **Amendment Tracking:** If you edit a past week's schedule, goals, or KPIs, the changes are flagged with an asterisk, ensuring an honest record.  
 * **Seamless Week Advancement:** At the end of the week, a single click archives the current week and sets up a fresh week for planning.
 
+### **The Journal**
+
+The Journal provides a space for free-form entries and serves as a log for your weekly goals.
+
+*   **Free-form Entries:** Create, edit, and delete journal entries with a title, content, and an optional icon.
+*   **Weekly Goal Logging:** The journal automatically displays your weekly goals, providing a historical record of your focus over time.
+*   **Flexible Sorting:** View your entries chronologically (grouped by week) or grouped by their assigned icon.
+*   **Customizable Goal Icon:** To better integrate weekly goals into your categorized view, you can now set a custom icon for them.
+    *   In `Advanced Options` > `Journal Settings`, you can specify any Font Awesome icon class (e.g., `fa-solid fa-bullseye`).
+    *   When sorting the journal by icon, all your weekly goals will be grouped under this custom icon.
+*   **Collapsible Icon Groups:** To make the icon-sorted view easier to navigate, icon groups are now collapsible.
+    *   Click the header of any icon group to expand or collapse it.
+    *   The application will remember the state of each group, so your preferences are saved for your next visit.
+    *   The system is dynamic: if you delete all entries for a specific icon, its collapse/expand setting is automatically removed.
+
 ## **Project Updates**
 
 This section provides a high-level overview of the project's status, recent updates, and future plans.

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
                             <option value="desc">Descending</option>
                             <option value="asc">Ascending</option>
                         </select>
-                        <button id="add-journal-entry-btn" class="themed-button-primary">New Entry</button>
+                        <button id="add-journal-entry-btn" class="text-white font-bold py-2 px-4 rounded-md transition-colors themed-button-secondary">New Entry</button>
                     </div>
                 </div>
                 <div id="journal-list" class="space-y-4">
@@ -621,6 +621,12 @@
                     <legend>Vacation Mode</legend>
                     <div id="vacation-manager-content" class="space-y-4">
                         <!-- Vacation manager will be rendered here by JS -->
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <legend>Journal Settings</legend>
+                    <div id="journal-settings-content" class="space-y-4">
+                        <!-- Journal settings will be rendered here by JS -->
                     </div>
                 </fieldset>
             </div>

--- a/js/templates.js
+++ b/js/templates.js
@@ -275,7 +275,7 @@ export {
     editProgressTemplate, editCategoryTemplate, editStatusNameTemplate, restoreDefaultsConfirmationTemplate,
     taskGroupHeaderTemplate, bulkEditFormTemplate, dataMigrationModalTemplate, sensitivityControlsTemplate,
     historyDeleteConfirmationTemplate, taskViewDeleteConfirmationTemplate, vacationManagerTemplate,
-    taskViewHistoryDeleteConfirmationTemplate
+    taskViewHistoryDeleteConfirmationTemplate, journalSettingsTemplate
 };
 
 function vacationManagerTemplate(vacations, categories) {
@@ -407,6 +407,16 @@ function dataMigrationModalTemplate() {
                     <button id="run-confirm-btn" class="themed-button-secondary">Confirm Migration</button>
                 </div>
             </div>
+        </div>
+    `;
+}
+
+function journalSettingsTemplate(settings) {
+    return `
+        <div>
+            <label for="weekly-goal-icon-input" class="form-label">Weekly Goal Icon:</label>
+            <input type="text" id="weekly-goal-icon-input" value="${settings.weeklyGoalIcon}" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+            <p class="form-hint">Set the Font Awesome icon for weekly goals in the journal view.</p>
         </div>
     `;
 }


### PR DESCRIPTION
This commit introduces several enhancements to the Journal and Dashboard features based on user feedback.

Features:
- **Collapsible Journal Groups:** When sorting the journal by icon, each icon group is now a collapsible section. The application remembers the collapsed/expanded state of each group across sessions.
- **Configurable Weekly Goal Icon:** A new "Journal Settings" section has been added to the Advanced Options modal. Users can now specify a custom Font Awesome icon for their weekly goals, allowing them to be grouped with other entries when sorting by icon.
- **Dynamic State Management:** The system now dynamically cleans up saved collapse states for icons that are no longer in use, preventing stale data from accumulating in user settings.

Bug Fixes:
- **Weekly Goal Persistence:** The weekly goal set on the dashboard now correctly persists and reloads when navigating between different application views.
- **Journal Auto-Refresh:** The journal view now updates immediately when a weekly goal is modified, without requiring a manual page refresh.

UI Improvements:
- The "New Entry" button in the Journal view has been restyled to match the "Add New Task" button for better visual consistency.