### PR TITLE
feat: Reorganize Advanced Options menu for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The core of the application is a dynamic and intelligent task management system.
 * **In-Depth Customization:**  
   * **Task Icons:** Assign a unique icon to each task using Font Awesome classes for quick visual identification.  
   * **Customizable Task Cards:** From the Advanced Options menu, choose exactly which details you want to see on your task cards, such as due date, duration, category, and more.  
-  * **Collapsible Advanced Options:** The Advanced Options menu has been reorganized into logical, collapsible sections (General, Appearance, etc.). Click on any section header to expand or collapse it, making the menu cleaner and easier to navigate. Your preferences are saved automatically.
+  * **Reorganized Advanced Options:** The Advanced Options menu has been completely reorganized for clarity and ease of use. Sections have been renamed and reordered into more intuitive groups: Theme and Color, Naming, Planner Sensitivity, Category Management, Vacation Schedule, Other Features, and Data & Notifications. All sections remain collapsible, and your preferences are saved automatically.
   * **Categories:** Create an unlimited number of color-coded categories to organize your tasks.  
   * **Status Names & Colors:** Edit the names and colors for each status (Ready, Overdue, etc.) to match your personal workflow.  
   * **Advanced Theming Engine:** The application features a powerful, dynamic theming system that ensures readability and a cohesive look across the entire interface.

--- a/index.html
+++ b/index.html
@@ -476,47 +476,10 @@
             <h2 class="text-2xl font-semibold mb-6 text-gray-700">Advanced Options</h2>
             <div id="advanced-options-content" class="space-y-2">
 
-                <!-- General Settings Section -->
-                <div class="collapsible-section" data-section-key="general">
-                    <h3 class="collapsible-header">
-                        <span>General Settings</span>
-                        <i class="fas fa-chevron-down"></i>
-                    </h3>
-                    <div class="collapsible-content">
-                        <fieldset>
-                            <legend>View Options</legend>
-                            <div id="restore-defaults-container" class="mt-4">
-                                <button data-action="restoreDefaults" class="w-full bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded themed-button-tertiary">Restore All View Defaults</button>
-                            </div>
-                        </fieldset>
-                        <fieldset>
-                            <legend>Application Settings</legend>
-                            <div class="space-y-2">
-                                <div>
-                                    <label for="app-title-input" class="form-label">Application Title:</label>
-                                    <input type="text" id="app-title-input" placeholder="Enter a new title" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                                </div>
-                                <div>
-                                    <label for="app-subtitle-input" class="form-label">Application Subtitle:</label>
-                                    <input type="text" id="app-subtitle-input" placeholder="Enter a new subtitle" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                                </div>
-                                <div>
-                                    <label for="app-goal-label-input" class="form-label">Weekly Goal Label:</label>
-                                    <input type="text" id="app-goal-label-input" placeholder="Enter a new label" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
-                                </div>
-                                <div class="flex items-center justify-between">
-                                    <label for="time-format-toggle" class="form-label mb-0">Use 24-Hour Time Format:</label>
-                                    <input type="checkbox" id="time-format-toggle" data-action="toggleTimeFormat" class="toggle-checkbox h-6 w-12 rounded-full p-1 bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 appearance-none cursor-pointer">
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                </div>
-
-                <!-- Appearance Section -->
+                <!-- Theme and Color Section -->
                 <div class="collapsible-section" data-section-key="appearance">
                     <h3 class="collapsible-header">
-                        <span>Appearance</span>
+                        <span>Theme and Color</span>
                         <i class="fas fa-chevron-down"></i>
                     </h3>
                     <div class="collapsible-content">
@@ -579,13 +542,50 @@
                                 </label>
                             </div>
                         </fieldset>
+                        <fieldset>
+                            <legend>View Options</legend>
+                            <div id="restore-defaults-container" class="mt-4">
+                                <button data-action="restoreDefaults" class="w-full bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded themed-button-tertiary">Restore All View Defaults</button>
+                            </div>
+                        </fieldset>
                     </div>
                 </div>
 
-                <!-- Feature Settings Section -->
-                <div class="collapsible-section" data-section-key="features">
+                <!-- Naming Section -->
+                <div class="collapsible-section" data-section-key="general">
                     <h3 class="collapsible-header">
-                        <span>Feature Settings</span>
+                        <span>Naming</span>
+                        <i class="fas fa-chevron-down"></i>
+                    </h3>
+                    <div class="collapsible-content">
+                        <fieldset>
+                            <legend>Application Naming</legend>
+                            <div class="space-y-2">
+                                <div>
+                                    <label for="app-title-input" class="form-label">Application Title:</label>
+                                    <input type="text" id="app-title-input" placeholder="Enter a new title" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                </div>
+                                <div>
+                                    <label for="app-subtitle-input" class="form-label">Application Subtitle:</label>
+                                    <input type="text" id="app-subtitle-input" placeholder="Enter a new subtitle" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                </div>
+                                <div>
+                                    <label for="app-goal-label-input" class="form-label">Weekly Goal Label:</label>
+                                    <input type="text" id="app-goal-label-input" placeholder="Enter a new label" class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <label for="time-format-toggle" class="form-label mb-0">Use 24-Hour Time Format:</label>
+                                    <input type="checkbox" id="time-format-toggle" data-action="toggleTimeFormat" class="toggle-checkbox h-6 w-12 rounded-full p-1 bg-gray-200 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50 appearance-none cursor-pointer">
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+
+                <!-- Planner Sensitivity Section -->
+                <div class="collapsible-section" data-section-key="sensitivity">
+                    <h3 class="collapsible-header">
+                        <span>Planner Sensitivity</span>
                         <i class="fas fa-chevron-down"></i>
                     </h3>
                     <div class="collapsible-content">
@@ -595,6 +595,16 @@
                                 <!-- This content will be rendered by a new template -->
                             </div>
                         </fieldset>
+                    </div>
+                </div>
+
+                <!-- Category Management Section -->
+                <div class="collapsible-section" data-section-key="category">
+                    <h3 class="collapsible-header">
+                        <span>Category Management</span>
+                        <i class="fas fa-chevron-down"></i>
+                    </h3>
+                    <div class="collapsible-content">
                         <fieldset>
                             <legend>Category Management</legend>
                             <div id="category-manager-list" class="space-y-2">
@@ -609,6 +619,32 @@
                                 <p class="text-gray-500 italic">No categories to filter.</p>
                             </div>
                         </fieldset>
+                    </div>
+                </div>
+
+                <!-- Vacation Schedule Section -->
+                <div class="collapsible-section" data-section-key="vacation">
+                    <h3 class="collapsible-header">
+                        <span>Vacation Schedule</span>
+                        <i class="fas fa-chevron-down"></i>
+                    </h3>
+                    <div class="collapsible-content">
+                        <fieldset>
+                            <legend>Vacation Mode</legend>
+                            <div id="vacation-manager-content" class="space-y-4">
+                                <!-- Vacation manager will be rendered here by JS -->
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+
+                <!-- Other Features Section -->
+                <div class="collapsible-section" data-section-key="other">
+                    <h3 class="collapsible-header">
+                        <span>Other Features</span>
+                        <i class="fas fa-chevron-down"></i>
+                    </h3>
+                    <div class="collapsible-content">
                         <fieldset>
                             <legend>Planner Integration</legend>
                             <div>
@@ -623,12 +659,6 @@
                             </div>
                         </fieldset>
                         <fieldset>
-                            <legend>Vacation Mode</legend>
-                            <div id="vacation-manager-content" class="space-y-4">
-                                <!-- Vacation manager will be rendered here by JS -->
-                            </div>
-                        </fieldset>
-                        <fieldset>
                             <legend>Journal Settings</legend>
                             <div id="journal-settings-content" class="space-y-4">
                                 <!-- Journal settings will be rendered here by JS -->
@@ -637,10 +667,10 @@
                     </div>
                 </div>
 
-                <!-- Advanced Section -->
+                <!-- Data & Notifications Section -->
                 <div class="collapsible-section" data-section-key="advanced">
                     <h3 class="collapsible-header">
-                        <span>Advanced</span>
+                        <span>Data & Notifications</span>
                         <i class="fas fa-chevron-down"></i>
                     </h3>
                     <div class="collapsible-content">


### PR DESCRIPTION
Reorders and renames the sections within the Advanced Options modal to create a more intuitive user experience, based on user feedback.

- The main "Appearance" section is renamed to "Theme and Color" and moved to the top.
- The "General Settings" section is renamed to "Naming".
- The large "Feature Settings" section is broken down into more specific, logical groups: "Planner Sensitivity", "Category Management", "Vacation Schedule", and "Other Features".
- The "Advanced" section at the bottom is renamed to "Data & Notifications".
- The "Restore all default views" button is moved into the "Theme and Color" section.
- The README.md has been updated to reflect these changes.